### PR TITLE
python3: fix unexpected keyword argument 'encoding'

### DIFF
--- a/resources/lib/tools.py
+++ b/resources/lib/tools.py
@@ -56,7 +56,7 @@ def jsonrpc(query):
     querystring = {"jsonrpc": "2.0", "id": 1}
     querystring.update(query)
     try:
-        response = json.loads(xbmc.executeJSONRPC(json.dumps(querystring, encoding='utf-8')))
+        response = json.loads(xbmc.executeJSONRPC(json.dumps(querystring)))
         if 'result' in response: return response['result']
     except TypeError as e:
         writeLog('Error executing JSON RPC: %s' % (e), xbmc.LOGERROR)


### PR DESCRIPTION
Fixes the following issue:
```
2020-02-17 02:52:12.690 T:1351  NOTICE: [script.program.driverselect 0.1.7] starting addon
2020-02-17 02:52:12.690 T:1351   ERROR: [script.program.driverselect 0.1.7] Error executing JSON RPC: __init__() got an unexpected keyword argument 'encoding'
2020-02-17 02:52:12.690 T:1351   ERROR: [script.program.driverselect 0.1.7] Could not access addon library
```